### PR TITLE
Cades 2746

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,26 @@ FIND_PACKAGE( Boost REQUIRED )
 
 ADD_DEFINITIONS(-DUNIX -DSIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P})
 
+EXECUTE_PROCESS(
+    COMMAND bash -c "if type dpkg > /dev/null 2>&1; then dpkg -l|grep cprocsp-pki-cades|awk ' { print $3 } '; else rpm -qa|grep cprocsp-pki-cades; fi|cut -d. -f1|cut -d- -f1"
+    OUTPUT_VARIABLE CPRO_CADES_VERSION_MAJOR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+EXECUTE_PROCESS(
+    COMMAND bash -c "if type dpkg > /dev/null 2>&1; then dpkg -l|grep cprocsp-pki-cades|awk ' { print $3 } '; else rpm -qa|grep cprocsp-pki-cades; fi|cut -d. -f2|cut -d- -f1"
+    OUTPUT_VARIABLE CPRO_CADES_VERSION_MINOR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+EXECUTE_PROCESS(
+    COMMAND bash -c "if type dpkg > /dev/null 2>&1; then dpkg -l|grep cprocsp-pki-cades|awk ' { print $3 } '; else rpm -qa|grep cprocsp-pki-cades; fi|cut -d. -f3|cut -d- -f1"
+    OUTPUT_VARIABLE CPRO_CADES_VERSION_BUILD
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+ADD_DEFINITIONS(-DCPRO_CADES_VERSION_MAJOR=${CPRO_CADES_VERSION_MAJOR})
+ADD_DEFINITIONS(-DCPRO_CADES_VERSION_MINOR=${CPRO_CADES_VERSION_MINOR})
+ADD_DEFINITIONS(-DCPRO_CADES_VERSION_BUILD=${CPRO_CADES_VERSION_BUILD})
+MESSAGE("-- cprocsp-pki-cades: ${CPRO_CADES_VERSION_MAJOR}.${CPRO_CADES_VERSION_MINOR}.${CPRO_CADES_VERSION_BUILD}")
+
 #SET(CMAKE_BUILD_TYPE Debug)
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-write-strings")
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")

--- a/PyCades.cpp
+++ b/PyCades.cpp
@@ -30,7 +30,7 @@
 #include "PyCadesSymmetricAlgorithm.h"
 #include "PyCadesVersion.h"
 
-#define PYCADES_VERSION "0.1.70194"
+#define PYCADES_VERSION "0.1.70195"
 static PyObject * pycades_ModuleVersion(PyObject *self, PyObject *args)
 {
     return Py_BuildValue("s", PYCADES_VERSION);

--- a/PyCadesSignedData.cpp
+++ b/PyCadesSignedData.cpp
@@ -320,6 +320,42 @@ static PyObject *SignedData_AdditionalStore(SignedData *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+#if IS_CADES_VERSION_GREATER_EQUAL(2, 0, 15262)
+static PyObject *SignedData_GetMsgType(SignedData *self, PyObject *args)
+{
+    char *szSignedMessage = "";
+    if (!PyArg_ParseTuple(args, "s", &szSignedMessage))
+    {
+        return NULL;
+    }
+
+    CStringBlob strBlobMessage(szSignedMessage, strlen(szSignedMessage));
+    DWORD result = 0;
+    HR_METHOD_ERRORCHECK_RETURN(self->m_pCppCadesImpl->GetMsgType(strBlobMessage, &result));
+    return Py_BuildValue("l", result);
+}
+
+static PyObject *SignedData_IsMsgType(SignedData *self, PyObject *args)
+{
+    char *szSignedMessage = "";
+    long lCadesType = CADESCOM_CADES_DEFAULT;
+    if (!PyArg_ParseTuple(args, "sl", &szSignedMessage, &lCadesType))
+    {
+        return NULL;
+    }
+
+    CStringBlob strBlobMessage(szSignedMessage, strlen(szSignedMessage));
+    DWORD dwSignType = (DWORD)lCadesType;
+    BOOL bIsType;
+    HR_METHOD_ERRORCHECK_RETURN(self->m_pCppCadesImpl->IsMsgType(strBlobMessage, dwSignType, &bIsType));
+    if (bIsType)
+    {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+#endif
+
 static PyGetSetDef SignedData_getset[] = {
     {"ContentEncoding", (getter)SignedData_getContentEncoding, (setter)SignedData_setContentEncoding, "ContentEncoding", NULL},
     {"Content", (getter)SignedData_getContent, (setter)SignedData_setContent, "Content", NULL},
@@ -340,6 +376,10 @@ static PyMethodDef SignedData_methods[] = {
     {"VerifyCades", (PyCFunction)SignedData_VerifyCades, METH_VARARGS, "VerifyCades"},
     {"VerifyHash", (PyCFunction)SignedData_VerifyHash, METH_VARARGS, "VerifyHash"},
     {"AdditionalStore", (PyCFunction)SignedData_AdditionalStore, METH_VARARGS, "AdditionalStore"},
+#if IS_CADES_VERSION_GREATER_EQUAL(2, 0, 15262)
+    {"GetMsgType", (PyCFunction)SignedData_GetMsgType, METH_VARARGS, "GetMsgType"},
+    {"IsMsgType", (PyCFunction)SignedData_GetMsgType, METH_VARARGS, "IsMsgType"},
+#endif
     {NULL} /* Sentinel */
 };
 

--- a/PyCadesSymmetricAlgorithm.cpp
+++ b/PyCadesSymmetricAlgorithm.cpp
@@ -146,6 +146,7 @@ static PyObject *SymmetricAlgorithm_ImportKey(SymmetricAlgorithm *self, PyObject
     Py_RETURN_NONE;
 }
 
+#if IS_CADES_VERSION_GREATER_EQUAL(2, 0, 14892)
 static int SymmetricAlgorithm_setLegacyPluginSymmetricExport(SymmetricAlgorithm *self, PyObject *value)
 {
     int bLegacyPluginSymmetricExport = 0;
@@ -182,11 +183,14 @@ static PyObject *SymmetricAlgorithm_SetPadding(SymmetricAlgorithm *self, PyObjec
     HR_METHOD_ERRORCHECK_RETURN(self->m_pCppCadesImpl->SetPadding(Padding));
     Py_RETURN_NONE;
 }
+#endif
 
 static PyGetSetDef SymmetricAlgorithm_getset[] = {
     {"DiversData", (getter)SymmetricAlgorithm_getDiversData, (setter)SymmetricAlgorithm_setDiversData, "DiversData", NULL},
     {"IV", (getter)SymmetricAlgorithm_getIV, (setter)SymmetricAlgorithm_setIV, "IV", NULL},
+#if IS_CADES_VERSION_GREATER_EQUAL(2, 0, 14892)
     {"LegacyPluginSymmetricExport", NULL, (setter)SymmetricAlgorithm_setLegacyPluginSymmetricExport, "LegacyPluginSymmetricExport", NULL},
+#endif
     {NULL} /* Sentinel */
 };
 
@@ -197,8 +201,10 @@ static PyMethodDef SymmetricAlgorithm_methods[] = {
     {"GenerateKey", (PyCFunction)SymmetricAlgorithm_GenerateKey, METH_VARARGS, "GenerateKey"},
     {"ExportKey", (PyCFunction)SymmetricAlgorithm_ExportKey, METH_VARARGS, "ExportKey"},
     {"ImportKey", (PyCFunction)SymmetricAlgorithm_ImportKey, METH_VARARGS, "ImportKey"},
+#if IS_CADES_VERSION_GREATER_EQUAL(2, 0, 14892)
     {"SetMode", (PyCFunction)SymmetricAlgorithm_SetMode, METH_VARARGS, "SetMode"},
     {"SetPadding", (PyCFunction)SymmetricAlgorithm_SetPadding, METH_VARARGS, "SetPadding"},
+#endif
     {NULL} /* Sentinel */
 };
 

--- a/stdafx.h
+++ b/stdafx.h
@@ -17,6 +17,11 @@
 #define RETURN_ATL_STRINGL RETURN_ATL_STRINGL_W
 #endif
 
+#define IS_CADES_VERSION_GREATER_EQUAL(major, minor, build) \
+    (CPRO_CADES_VERSION_MAJOR > (major) || \
+    (CPRO_CADES_VERSION_MAJOR == (major) && CPRO_CADES_VERSION_MINOR > (minor)) || \
+    (CPRO_CADES_VERSION_MAJOR == (major) && CPRO_CADES_VERSION_MINOR == (minor) && CPRO_CADES_VERSION_BUILD >= (build)))
+
 #include <Python.h>
 #include <structmember.h>
 


### PR DESCRIPTION
Добавлены определение версии cprocsp-pki-cades и макрос для сравнения версии. Для объекта SymmetricAlgorithm добавлено использование IS_CADES_VERSION_GREATER_EQUAL. Добавлена поддержка SignedData.IsMsgType/GetMsgType. Увеличена версия pycades после добавления новых методов.

