### PR TITLE
Update sample_sign_verify_xml.py

### DIFF
--- a/sample_sign_verify_xml.py
+++ b/sample_sign_verify_xml.py
@@ -15,10 +15,10 @@ content_to_sign += "XML Security Library example: Original XML doc file for sign
 content_to_sign += "-->"
 content_to_sign += "<Envelope xmlns=\"urn:envelope\">"
 content_to_sign += "  <Data>"
-content_to_sign += "	Hello, World!"
+content_to_sign += "  Hello, World!"
 content_to_sign += "  </Data>"
 content_to_sign += "  <Node xml:id=\"nodeID\">"
-content_to_sign += "	Hello, Node!"
+content_to_sign += "  Hello, Node!"
 content_to_sign += "  </Node>" + " " + "</Envelope>"
 
 signedXML = pycades.SignedXML()


### PR DESCRIPTION
fix: 
```
----
Traceback (most recent call last):
  File "/test/sample_sign_verify_xml.py", line 34, in <module>
    assert(signature == signedXML.Content), "Incorrect value of SignedXML.Verify result"
                        ^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb1 in position 4808: invalid start byte
```
